### PR TITLE
BUGFIX: use deactivate request for v2 api

### DIFF
--- a/Classes/Domain/Service/CleverReachApiService.php
+++ b/Classes/Domain/Service/CleverReachApiService.php
@@ -242,7 +242,7 @@ class CleverReachApiService
     {
         $this->fireRequest(
             'PUT',
-            'groups.json/' . $groupId . '/receivers/' . $receiverIdOrEmail . '/deactivate'
+            'groups.json/' . $groupId . '/receivers/' . $receiverIdOrEmail . '/setinactive'
         );
     }
 


### PR DESCRIPTION
I made a mistake in implementing the deactivation function. I used the documentation for the v3 api. In your package you use the v2 api, but I didn't notice this until later. This bugfix should fix this.