### PR TITLE
FEATURE: Adapt to changes in neos 9

### DIFF
--- a/Classes/Controller/AjaxController.php
+++ b/Classes/Controller/AjaxController.php
@@ -7,7 +7,11 @@ use KaufmannDigital\CleverReach\Exception\CleverReachException;
 use Neos\Error\Messages\Error;
 use Neos\Flow\Annotations as Flow;
 use KaufmannDigital\CleverReach\Domain\Service\SubscriptionService;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Node\NodeAggregateId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Flow\I18n\Detector;
 use Neos\Flow\I18n\Locale;
 use Neos\Flow\I18n\Translator;
@@ -31,39 +35,34 @@ class AjaxController extends RestController
      */
     protected $locale;
 
-    /**
-     * @Flow\Inject
-     * @var Translator
-     */
-    protected $translator;
+    #[Flow\Inject]
+    protected Translator $translator;
 
-    /**
-     * @Flow\Inject
-     * @var Detector
-     */
-    protected $languageDetector;
+    #[Flow\Inject]
+    protected Detector $languageDetector;
 
-    /**
-     * @Flow\Inject
-     * @var SubscriptionService
-     */
-    protected $subscriptionService;
+    #[Flow\Inject]
+    protected SubscriptionService $subscriptionService;
+
+    #[Flow\Inject]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
 
     public function initializeAction()
     {
-        $acceptLanguage = $this->request->getHttpRequest()->getHeader('Accept-Language');
-        $this->locale = $this->languageDetector->detectLocaleFromHttpHeader($acceptLanguage[0]);
+        $acceptLanguage = $this->request->getHttpRequest()->getHeaderLine('Accept-Language');
+        $this->locale = $this->languageDetector->detectLocaleFromHttpHeader($acceptLanguage);
     }
 
     /**
      * @Flow\Validate(argumentName="receiverData", type="KaufmannDigital.CleverReach:ReceiverData")
      * @Flow\Validate(argumentName="receiverData", type="KaufmannDigital.CleverReach:ReceiverNotExistsInGroup")
      * @param array $receiverData
-     * @param NodeInterface $registrationForm
+     * @param string $registrationFormAggregateId
      */
-    public function subscribeAction(array $receiverData, NodeInterface $registrationForm)
+    public function subscribeAction(array $receiverData, string $registrationFormAggregateId)
     {
+        $registrationForm = $this->resolveRegistrationFormNode($registrationFormAggregateId);
         try {
             $this->subscriptionService->subscribe($receiverData, $registrationForm, $this->request->getHttpRequest());
 
@@ -88,10 +87,11 @@ class AjaxController extends RestController
      * @Flow\Validate(argumentName="receiverData", type="KaufmannDigital.CleverReach:ReceiverData")
      * @Flow\Validate(argumentName="receiverData", type="KaufmannDigital.CleverReach:ReceiverExistsInGroup")
      * @param array $receiverData
-     * @param NodeInterface $registrationForm
+     * @param string $registrationFormAggregateId
      */
-    public function unsubscribeAction(array $receiverData, NodeInterface $registrationForm)
+    public function unsubscribeAction(array $receiverData, string $registrationFormAggregateId)
     {
+        $registrationForm = $this->resolveRegistrationFormNode($registrationFormAggregateId);
         try {
             $this->subscriptionService->unsubscribe($receiverData, $registrationForm, $this->request->getHttpRequest());
 
@@ -153,6 +153,16 @@ class AjaxController extends RestController
             $sourceName,
             'KaufmannDigital.CleverReach'
         );
+    }
+
+    private function resolveRegistrationFormNode(string $aggregateId): Node
+    {
+        $cr = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString('default'));
+        $contentGraph = $cr->getContentGraph(WorkspaceName::forLive());
+        $aggregate = $contentGraph->findNodeAggregateById(NodeAggregateId::fromString($aggregateId));
+        $dsp = array_values($aggregate->coveredDimensionSpacePoints->points)[0] ?? null;
+        return $cr->getContentSubgraph(WorkspaceName::forLive(), $dsp)
+            ->findNodeById($aggregate->nodeAggregateId);
     }
 
 }

--- a/Classes/Controller/SubscriptionController.php
+++ b/Classes/Controller/SubscriptionController.php
@@ -5,7 +5,7 @@ namespace KaufmannDigital\CleverReach\Controller;
 
 use Neos\Flow\Annotations as Flow;
 use KaufmannDigital\CleverReach\Domain\Service\SubscriptionService;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Mvc\Controller\ActionController;
 
 /**
@@ -16,11 +16,8 @@ use Neos\Flow\Mvc\Controller\ActionController;
 class SubscriptionController extends ActionController
 {
 
-    /**
-     * @Flow\Inject
-     * @var SubscriptionService
-     */
-    protected $subscriptionService;
+    #[Flow\Inject]
+    protected SubscriptionService $subscriptionService;
 
 
     /**
@@ -49,7 +46,7 @@ class SubscriptionController extends ActionController
      */
     public function subscribeAction(array $receiverData)
     {
-        /** @var NodeInterface $registrationForm */
+        /** @var Node $registrationForm */
         $registrationForm = $this->request->getInternalArgument('__node');
 
         $this->subscriptionService->subscribe($receiverData, $registrationForm, $this->request->getHttpRequest());
@@ -64,7 +61,7 @@ class SubscriptionController extends ActionController
      */
     public function unsubscribeAction(array $receiverData)
     {
-        /** @var NodeInterface $registrationForm */
+        /** @var Node $registrationForm */
         $registrationForm = $this->request->getInternalArgument('__node');
 
         $this->subscriptionService->unsubscribe($receiverData, $registrationForm, $this->request->getHttpRequest());

--- a/Classes/DataSource/CleverReachFormsDataSource.php
+++ b/Classes/DataSource/CleverReachFormsDataSource.php
@@ -4,7 +4,7 @@ namespace KaufmannDigital\CleverReach\DataSource;
 use Neos\Flow\Annotations as Flow;
 use KaufmannDigital\CleverReach\Domain\Service\CleverReachApiService;
 use Neos\Neos\Service\DataSource\AbstractDataSource;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
  * Class CleverReachFormsDataSource
@@ -19,14 +19,11 @@ class CleverReachFormsDataSource extends AbstractDataSource
     static protected $identifier = 'kaufmanndigital-cleverreach-forms';
 
 
-    /**
-     * @Flow\Inject
-     * @var CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
 
-    public function getData(NodeInterface $node = null, array $arguments = [])
+    public function getData(?Node $node = null, array $arguments = [])
     {
         $forms = $this->apiService->getForms();
         $data = [];

--- a/Classes/DataSource/CleverReachGroupsDataSource.php
+++ b/Classes/DataSource/CleverReachGroupsDataSource.php
@@ -4,7 +4,7 @@ namespace KaufmannDigital\CleverReach\DataSource;
 use Neos\Flow\Annotations as Flow;
 use KaufmannDigital\CleverReach\Domain\Service\CleverReachApiService;
 use Neos\Neos\Service\DataSource\AbstractDataSource;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 
 /**
  * Class CleverReachGroupsDataSource
@@ -19,14 +19,11 @@ class CleverReachGroupsDataSource extends AbstractDataSource
     static protected $identifier = 'kaufmanndigital-cleverreach-groups';
 
 
-    /**
-     * @Flow\Inject
-     * @var CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
 
-    public function getData(NodeInterface $node = null, array $arguments = [])
+    public function getData(?Node $node = null, array $arguments = [])
     {
         $groups = $this->apiService->getGroups();
 

--- a/Classes/Domain/Service/CleverReachApiService.php
+++ b/Classes/Domain/Service/CleverReachApiService.php
@@ -11,60 +11,31 @@ use KaufmannDigital\CleverReach\Exception\AuthenticationFailedException;
 use KaufmannDigital\CleverReach\Exception\CleverReachException;
 use KaufmannDigital\CleverReach\Exception\NotFoundException;
 use Neos\Cache\Frontend\StringFrontend;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
+use Neos\ContentRepository\Core\NodeType\NodeTypeName;
+use Neos\ContentRepository\Core\SharedModel\ContentRepository\ContentRepositoryId;
+use Neos\ContentRepository\Core\SharedModel\Workspace\WorkspaceName;
+use Neos\ContentRepositoryRegistry\ContentRepositoryRegistry;
 use Neos\Eel\FlowQuery\FlowQuery;
 use Neos\Flow\Cache\CacheManager;
-use Neos\Flow\Http\Client\CurlEngine;
-use Neos\Http\Factories\ServerRequestFactory;
-use Neos\Neos\Domain\Service\ContentContextFactory;
 use GuzzleHttp\Psr7\Uri;
-use Neos\Http\Factories\StreamFactory;
 
 class CleverReachApiService
 {
 
-    /**
-     * @Flow\InjectConfiguration()
-     * @var array
-     */
-    protected $settings;
-
-    /**
-     * @Flow\Inject
-     * @var CurlEngine
-     */
-    protected $requestEngine;
-
-
-    /**
-     * @Flow\Inject
-     * @var ServerRequestFactory
-     */
-    protected $serverRequestFactory;
-
-
-    /**
-     * @Flow\Inject
-     * @var StreamFactory
-     */
-    protected $streamFactory;
+    #[Flow\InjectConfiguration]
+    protected array $settings;
 
     /**
      * @var StringFrontend
      */
     protected $cache;
 
-    /**
-     * @Flow\Inject
-     * @var CacheManager
-     */
-    protected $cacheManager;
+    #[Flow\Inject]
+    protected CacheManager $cacheManager;
 
-    /**
-     * @Flow\Inject
-     * @var ContentContextFactory
-     */
-    protected $contextFactory;
+    #[Flow\Inject]
+    protected ContentRepositoryRegistry $contentRepositoryRegistry;
 
     /**
      * @var string
@@ -72,24 +43,38 @@ class CleverReachApiService
     protected $apiToken;
 
 
-    public function initializeObject()
+    public function initializeObject(): void
     {
         $credentials = $this->settings['credentials'];
-
-        $q = new FlowQuery([$this->contextFactory->create()->getCurrentSiteNode()]);
-        $configurationNode = $q->find('[instanceof KaufmannDigital.CleverReach:Mixin.NodeWithCleverReachCredentials]')->get(0);
-
-        if (
-            $configurationNode instanceof NodeInterface
-            && !empty($configurationNode->getProperty('cleverReachClientId'))
-            && !empty($configurationNode->getProperty('cleverReachClientSecret'))
-        ) {
-            $credentials = [
-                'clientId' => $configurationNode->getProperty('cleverReachClientId'),
-                'clientSecret' => $configurationNode->getProperty('cleverReachClientSecret'),
-            ];
+        try {
+            $cr = $this->contentRepositoryRegistry->get(ContentRepositoryId::fromString('default'));
+            $contentGraph = $cr->getContentGraph(WorkspaceName::forLive());
+            $sitesAggregate = $contentGraph->findRootNodeAggregateByType(
+                NodeTypeName::fromString('Neos.Neos:Sites')
+            );
+            $dsp = array_values($sitesAggregate->coveredDimensionSpacePoints->points)[0] ?? null;
+            if ($dsp !== null) {
+                $subgraph = $cr->getContentSubgraph(WorkspaceName::forLive(), $dsp);
+                $sitesNode = $subgraph->findNodeById($sitesAggregate->nodeAggregateId);
+                if ($sitesNode !== null) {
+                    $configNode = (new FlowQuery([$sitesNode]))
+                        ->find('[instanceof KaufmannDigital.CleverReach:Mixin.NodeWithCleverReachCredentials]')
+                        ->get(0);
+                    if (
+                        $configNode instanceof Node
+                        && !empty($configNode->getProperty('cleverReachClientId'))
+                        && !empty($configNode->getProperty('cleverReachClientSecret'))
+                    ) {
+                        $credentials = [
+                            'clientId' => $configNode->getProperty('cleverReachClientId'),
+                            'clientSecret' => $configNode->getProperty('cleverReachClientSecret'),
+                        ];
+                    }
+                }
+            }
+        } catch (\Exception $e) {
+            // Fall back to Settings.yaml credentials
         }
-
         $this->apiToken = $this->authenticate($credentials);
     }
 
@@ -406,7 +391,7 @@ class CleverReachApiService
     {
         //Build uri and set GET-Arguments
         if ($method === 'GET' && $arguments !== null) {
-            $uri->setQuery(http_build_query($arguments));
+            $uri = $uri->withQuery(http_build_query($arguments));
         }
 
         $request = new Request(
@@ -416,7 +401,7 @@ class CleverReachApiService
                 'Content-Type' => 'application/json; charset=utf-8',
                 'Authorization' => 'Bearer ' . $this->apiToken
             ],
-            $method !== 'GET' && $arguments !== null ? \GuzzleHttp\json_encode($arguments) : null
+            $method !== 'GET' && $arguments !== null ? json_encode($arguments) : null
         );
 
         //Fire request and get response-body

--- a/Classes/Domain/Service/SubscriptionService.php
+++ b/Classes/Domain/Service/SubscriptionService.php
@@ -2,11 +2,11 @@
 
 namespace KaufmannDigital\CleverReach\Domain\Service;
 
-use GuzzleHttp\Psr7\ServerRequest;
 use KaufmannDigital\CleverReach\Exception\NotFoundException;
-use Neos\ContentRepository\Domain\Model\NodeInterface;
-use Neos\Flow\Validation\ValidatorResolver;
+use Neos\ContentRepository\Core\Projection\ContentGraph\Node;
 use Neos\Flow\Annotations as Flow;
+use Neos\Flow\Validation\ValidatorResolver;
+use Psr\Http\Message\ServerRequestInterface;
 
 /**
  * Class SubscriptionService
@@ -16,33 +16,27 @@ use Neos\Flow\Annotations as Flow;
 class SubscriptionService
 {
 
-    /**
-     * @Flow\Inject
-     * @var CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
-    /**
-     * @Flow\Inject
-     * @var ValidatorResolver
-     */
-    protected $validatorResolver;
+    #[Flow\Inject]
+    protected ValidatorResolver $validatorResolver;
 
 
     /**
      * @param array $receiverData
-     * @param NodeInterface $registrationForm
-     * @param ServerRequest|null $httpRequest
+     * @param Node $registrationForm
+     * @param ServerRequestInterface|null $httpRequest
      */
-    public function subscribe(array $receiverData, NodeInterface $registrationForm, ServerRequest $httpRequest = null)
+    public function subscribe(array $receiverData, Node $registrationForm, ServerRequestInterface $httpRequest = null)
     {
-        $groupId = $registrationForm->getProperty('groupId');
+        $groupId = (int)$registrationForm->getProperty('groupId');
         $formId = $registrationForm->getProperty('formId');
         $useDOI = $registrationForm->getProperty('useDOI');
 
         //Try to get existing receiver. Only if the NotFoundException is thrown, we should create a new one.
         try {
-            $receiver = $this->apiService->getReceiverFromGroup($receiverData['email'], $receiverData['groupId']);
+            $receiver = $this->apiService->getReceiverFromGroup($receiverData['email'], (int)$receiverData['groupId']);
         } catch (NotFoundException $exception) {
             //Add user to list
             $this->apiService->addReceiver($receiverData, $groupId, !$useDOI);
@@ -52,8 +46,8 @@ class SubscriptionService
         if ($useDOI === true) {
             $doiData = [
                 'user_ip' => $httpRequest->getServerParams()['X_FORWARDED_FOR'] ?? $httpRequest->getServerParams()['REMOTE_ADDR'],
-                'referer' => $httpRequest->getHeader('Referer'),
-                'user_agent' => $httpRequest->getHeader('User-Agent')
+                'referer' => $httpRequest->getHeaderLine('Referer'),
+                'user_agent' => $httpRequest->getHeaderLine('User-Agent')
             ];
 
             $this->apiService->sendDoubleOptInMail($receiverData['email'], $formId, $doiData);
@@ -62,12 +56,12 @@ class SubscriptionService
 
     /**
      * @param array $receiverData
-     * @param NodeInterface $registrationForm
-     * @param ServerRequest|null $httpRequest
+     * @param Node $registrationForm
+     * @param ServerRequestInterface|null $httpRequest
      */
-    public function unsubscribe(array $receiverData, NodeInterface $registrationForm, ServerRequest $httpRequest = null)
+    public function unsubscribe(array $receiverData, Node $registrationForm, ServerRequestInterface $httpRequest = null)
     {
-        $groupId = $registrationForm->getProperty('groupId');
+        $groupId = (int)$registrationForm->getProperty('groupId');
         $formId = $registrationForm->getProperty('formId');
         $useDOI = $registrationForm->getProperty('useDOI');
 
@@ -75,8 +69,8 @@ class SubscriptionService
         if ($useDOI === true) {
             $doiData = [
                 'user_ip' => $httpRequest->getServerParams()['X_FORWARDED_FOR'] ?? $httpRequest->getServerParams()['REMOTE_ADDR'],
-                'referer' => $httpRequest->getHeader('Referer'),
-                'user_agent' => $httpRequest->getHeader('User-Agent')
+                'referer' => $httpRequest->getHeaderLine('Referer'),
+                'user_agent' => $httpRequest->getHeaderLine('User-Agent')
             ];
 
             $this->apiService->sendDoubleOptOutMail($receiverData['email'], $formId, $doiData);

--- a/Classes/Validation/Validator/ReceiverDataValidator.php
+++ b/Classes/Validation/Validator/ReceiverDataValidator.php
@@ -3,7 +3,6 @@
 namespace KaufmannDigital\CleverReach\Validation\Validator;
 
 
-use KaufmannDigital\CleverReach\Domain\Model\ReceiverData;
 use KaufmannDigital\CleverReach\Domain\Service\CleverReachApiService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Validation\Validator\AbstractValidator;
@@ -15,11 +14,8 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
 class ReceiverDataValidator extends AbstractValidator
 {
 
-    /**
-     * @Flow\Inject
-     * @var  CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
 
     /**

--- a/Classes/Validation/Validator/ReceiverExistsInGroupValidator.php
+++ b/Classes/Validation/Validator/ReceiverExistsInGroupValidator.php
@@ -3,7 +3,6 @@
 namespace KaufmannDigital\CleverReach\Validation\Validator;
 
 
-use KaufmannDigital\CleverReach\Domain\Model\ReceiverData;
 use KaufmannDigital\CleverReach\Domain\Service\CleverReachApiService;
 use Neos\Flow\Annotations as Flow;
 use Neos\Flow\Validation\Validator\AbstractValidator;
@@ -14,11 +13,8 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
  */
 class ReceiverExistsInGroupValidator extends AbstractValidator
 {
-    /**
-     * @Flow\Inject
-     * @var CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
     /**
      * @param array $value

--- a/Classes/Validation/Validator/ReceiverNotExistsInGroupValidator.php
+++ b/Classes/Validation/Validator/ReceiverNotExistsInGroupValidator.php
@@ -3,7 +3,6 @@
 namespace KaufmannDigital\CleverReach\Validation\Validator;
 
 
-use KaufmannDigital\CleverReach\Domain\Model\ReceiverData;
 use KaufmannDigital\CleverReach\Domain\Service\CleverReachApiService;
 use KaufmannDigital\CleverReach\Exception\NotFoundException;
 use Neos\Flow\Annotations as Flow;
@@ -15,11 +14,8 @@ use Neos\Flow\Validation\Validator\AbstractValidator;
  */
 class ReceiverNotExistsInGroupValidator extends AbstractValidator
 {
-    /**
-     * @Flow\Inject
-     * @var CleverReachApiService
-     */
-    protected $apiService;
+    #[Flow\Inject]
+    protected CleverReachApiService $apiService;
 
     /**
      * @param array $value
@@ -27,7 +23,7 @@ class ReceiverNotExistsInGroupValidator extends AbstractValidator
     public function isValid($value)
     {
         try {
-            $receiver = $this->apiService->getReceiverFromGroup($value['email'], $value['groupId']);
+            $receiver = $this->apiService->getReceiverFromGroup($value['email'], (int)$value['groupId']);
             if (isset($receiver['active']) && $receiver['active'] === true) {
                 $this->addError('This email address is already in our list', 1504541582);
             }

--- a/Resources/Private/Templates/Subscription/Index.html
+++ b/Resources/Private/Templates/Subscription/Index.html
@@ -49,7 +49,7 @@
 
         <input type="hidden" name="receiverData[source]" value="{sourceUrl}"/>
         <input type="hidden" name="receiverData[groupId]" value="{node.properties.groupId}"/>
-        <input type="hidden" name="registrationForm" value="{node.contextPath}"/>
+        <input type="hidden" name="registrationFormAggregateId" value="{node.aggregateId.value}"/>
 
         <input type="submit" value="{f:translate(id: 'button.submit.{formAction}', source: 'RegistrationForm')}"/>
     </form>

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
     "homepage": "https://www.kaufmann.digital",
     "license": "GPL-3.0-or-later",
     "require": {
-        "neos/neos": "^5.0 || ^7.0 || ^8.0",
+        "neos/neos": "^9.0",
         "guzzlehttp/guzzle": "*"
     },
     "autoload": {


### PR DESCRIPTION
This PR updates the package to work with neos 9 and the event-sourced CR.

Change summary (AI-generated):
  ---
  PHP: Removed NodeInterface / old CR imports (6 files)

  Replaced use Neos\ContentRepository\Domain\Model\NodeInterface with use Neos\ContentRepository\Core\Projection\ContentGraph\Node and updated all type hints
  accordingly in:
  - CleverReachFormsDataSource — getData(NodeInterface $node = null, ...) → getData(?Node $node = null, ...)
  - CleverReachGroupsDataSource — same
  - SubscriptionController — PHPDoc @var comment only
  - SubscriptionService — both method signatures
  - AjaxController — action parameters (see below)
  - CleverReachApiService — internal usage

  ---
  CleverReachApiService — major rewrite

  - Removed unused injections: CurlEngine, ServerRequestFactory, StreamFactory
  - Removed ContentContextFactory and its $contextFactory injection
  - Added ContentRepositoryRegistry injection
  - Rewrote initializeObject() to use the Neos 9 ES CR API: walks Neos.Neos:Sites root aggregate → finds first covered dimension space point → traverses to the
  sites node → uses FlowQuery to find a node with CleverReach credentials mixin; falls back to Settings.yaml on any exception
  - Fixed callUri(): $uri->setQuery(...) (no-op on immutable PSR-7 URI) → $uri = $uri->withQuery(...)
  - Fixed callUri(): \GuzzleHttp\json_encode() (deprecated) → json_encode()
  - Fixed DimensionSpacePointSet access: .first() (non-existent) → array_values(...->points)[0] ?? null

  ---
  SubscriptionService

  - ServerRequest → ServerRequestInterface (PSR-7 interface, not Guzzle concrete class)
  - $httpRequest->getHeader('Referer') (returns array) → $httpRequest->getHeaderLine('Referer')
  - $httpRequest->getHeader('User-Agent') → $httpRequest->getHeaderLine('User-Agent')
  - $groupId = $registrationForm->getProperty('groupId') → (int) cast (node/form properties arrive as strings; API methods declare int $groupId)
  - (int)$receiverData['groupId'] cast added at getReceiverFromGroup() call site

  ---
  AjaxController — significant changes

  - Replaced NodeInterface $registrationForm parameter with string $registrationFormAggregateId in both subscribeAction and unsubscribeAction
  - Added ContentRepositoryRegistry injection
  - Added private helper resolveRegistrationFormNode(string $aggregateId): Node — looks up the node aggregate by UUID, picks the first covered dimension space
  point, returns the node from the subgraph
  - Fixed initializeAction(): ->getHeader('Accept-Language')[0] → ->getHeaderLine('Accept-Language') (PSR-7 array vs. string)

  ---
  Validators (3 files)

  - Removed unused use KaufmannDigital\CleverReach\Domain\Model\ReceiverData import (class doesn't exist in the package)
  - ReceiverNotExistsInGroupValidator: added (int) cast on $value['groupId'] passed to getReceiverFromGroup()

  ---
  Fluid templates (2 files)

  Both IncubatorPackages/CleverReach/.../Subscription/Index.html and DistributionPackages/JvMTECH.Base/.../Subscription/Index.html:
  - Hidden field name: registrationForm → registrationFormAggregateId
  - Hidden field value: {node.contextPath} (removed in Neos 9) → {node.aggregateId.value} (UUID string on the Neos 9 Node object)

  ---
  @Flow\Inject annotations → PHP 8 attributes

  Converted all @Flow\Inject / @Flow\InjectConfiguration PHPDoc annotations to native PHP 8 #[Flow\Inject] / #[Flow\InjectConfiguration] attributes with typed
  properties across all modified files, eliminating false-positive "unused import" diagnostics.